### PR TITLE
close #57 シミュレータ拡張用APIのコース情報取得関数をControllerクラスに追加

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -36,5 +36,6 @@ INCLUDES += \
     -I$(mkfile_path)app \
     -I$(mkfile_path)module \
     -I$(mkfile_path)module/api \
+    -I$(ETROBO_HRP3_WORKSPACE)/etroboc_common \
 
 COPTS += -std=gnu++11

--- a/module/api/Controller.cpp
+++ b/module/api/Controller.cpp
@@ -339,3 +339,8 @@ void Controller::stopLiftMotor()
   this->resetArmMotorCount();
   this->tslpTsk(1500000);
 }
+
+int Controller::getCourseInfo(ETROBOC_COURSE_INFO_ID id)
+{
+  return ETRoboc_getCourceInfo(id);
+}

--- a/module/api/Controller.h
+++ b/module/api/Controller.h
@@ -8,21 +8,9 @@
 #include "Motor.h"
 #include "TouchSensor.h"
 #include "GyroSensor.h"
-// #include <array>
-/*
- * touch_sensor = EV3_PORT_1;
- * sonar_sensor = EV3_PORT_2;
- * color_sensor = EV3_PORT_3;
- * gyro_sensor  = EV3_PORT_4;
- *
- * left_motor   = EV3_PORT_C;
- * right_motor  = EV3_PORT_B;
- * lift_motor   = EV3_PORT_A;
- * tail_motor   = EV3_PORT_D;
- */
+#include "etroboc_ext.h"
 
-struct HsvStatus
-{
+struct HsvStatus {
   //色相 範囲(0~360)
   double hue;
   //彩度 範囲(0~100)
@@ -31,22 +19,12 @@ struct HsvStatus
   double value;
 };
 
-enum class Color
-{
-  black,
-  red,
-  green,
-  blue,
-  yellow,
-  white,
-  none
-};
+enum class Color { black, red, green, blue, yellow, white, none };
 
 using namespace ev3api;
 
-class Controller
-{
-public:
+class Controller {
+ public:
   Controller();
   TouchSensor touchSensor;
   ColorSensor colorSensor;
@@ -74,13 +52,13 @@ public:
   bool buttonIsPressedLeft();
   bool buttonIsPressedEnter();
   static float getBatteryVoltage();
-  static void tslpTsk(int time); // 引数はマイクロ秒で指定する
-  void getRawColor(int &r, int &g, int &b);
-  void convertHsv(int &r, int &g, int &b); // RGBをHSV変換する
+  static void tslpTsk(int time);  // 引数はマイクロ秒で指定する
+  void getRawColor(int& r, int& g, int& b);
+  void convertHsv(int& r, int& g, int& b);  // RGBをHSV変換する
   HsvStatus getHsv() const;
-  Color hsvToColor(const HsvStatus &status); // HSVから色を識別する
+  Color hsvToColor(const HsvStatus& status);  // HSVから色を識別する
   static void lcdFillRect(int x, int y, int h);
-  static void lcdDrawString(const char *str, int x, int y);
+  static void lcdDrawString(const char* str, int x, int y);
   static void lcdSetFont();
   int getLeftMotorCount();
   int getRightMotorCount();
@@ -88,8 +66,8 @@ public:
   void setLeftMotorPwm(const int pwm);
   void setRightMotorPwm(const int pwm);
   void setArmMotorPwm(const int pwm);
-  void setStandardWhite(const rgb_raw_t &rgb);
-  void setStandardBlack(const rgb_raw_t &rgb);
+  void setStandardWhite(const rgb_raw_t& rgb);
+  void setStandardBlack(const rgb_raw_t& rgb);
   void resetMotorCount();
   void stopMotor();
   int getAngleOfRotation();
@@ -110,7 +88,16 @@ public:
   void stopLiftMotor();
   void steer(int power, int turnRatio);
 
-private:
+  // シミュレータ用拡張API
+  /**
+   * @brief   コース情報の取得
+   * @param   コース情報取得関数用ID
+   * @return  指定されたidの情報
+   * @note    https://github.com/ETrobocon/etrobo/wiki/sim_extended_api
+   */
+  int getCourseInfo(ETROBOC_COURSE_INFO_ID id);
+
+ private:
   HsvStatus hsv;
   Motor liftMotor;
   Motor rightWheel;

--- a/test/dummy/Controller.cpp
+++ b/test/dummy/Controller.cpp
@@ -4,5 +4,39 @@
 
 // std::array<char, 256> Bluetooth::commands;
 // bool Bluetooth::is_start = false;
-std::array<Color, 10> Controller::colorBuffer = {Color::white};
+std::array<Color, 10> Controller::colorBuffer = { Color::white };
 int Controller::colorBufferCounter = 0;
+
+int Controller::getCourseInfo(ETROBOC_COURSE_INFO_ID id)
+{
+  // ETROBOC_COURSE_INFO_BLOCK_POS_STARTは、ETROBOC_COURSE_INFO_BLOCK_POS_BLACK1と等しいので省略(switch-case文では書けない)
+  // ETROBOC_COURSE_INFO_BLOCK_POS_ENDとETROBOC_COURSE_INFO_MAXは、ETROBOC_COURSE_INFO_BLOCK_POS_GREEN2に等しいので省略(switch-case文では書けない)
+  switch(id) {
+    case ETROBOC_COURSE_INFO_CARD_NUMBER:
+      return 3;
+    case ETROBOC_COURSE_INFO_BLOCK_NUMBER:
+      return 4;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_BLACK1:
+      return 67;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_BLACK2:
+      return 83;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_RED1:
+      return 72;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_RED2:
+      return 74;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_YELLOW1:
+      return 5;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_YELLOW2:
+      return 76;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_BLUE1:
+      return 65;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_BLUE2:
+      return 81;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_GREEN1:
+      return 70;
+    case ETROBOC_COURSE_INFO_BLOCK_POS_GREEN2:
+      return 7;
+    default:
+      return 0;
+  }
+}

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -26,6 +26,25 @@ typedef struct {
 
 enum class Color { black, red, green, blue, yellow, white, none };
 
+// シミュレータ用拡張API etroboc_ext.hからコピペ
+enum ETROBOC_COURSE_INFO_ID {
+  ETROBOC_COURSE_INFO_CARD_NUMBER,
+  ETROBOC_COURSE_INFO_BLOCK_NUMBER,
+  ETROBOC_COURSE_INFO_BLOCK_POS_START,
+  ETROBOC_COURSE_INFO_BLOCK_POS_BLACK1 = ETROBOC_COURSE_INFO_BLOCK_POS_START,
+  ETROBOC_COURSE_INFO_BLOCK_POS_BLACK2,
+  ETROBOC_COURSE_INFO_BLOCK_POS_RED1,
+  ETROBOC_COURSE_INFO_BLOCK_POS_RED2,
+  ETROBOC_COURSE_INFO_BLOCK_POS_YELLOW1,
+  ETROBOC_COURSE_INFO_BLOCK_POS_YELLOW2,
+  ETROBOC_COURSE_INFO_BLOCK_POS_BLUE1,
+  ETROBOC_COURSE_INFO_BLOCK_POS_BLUE2,
+  ETROBOC_COURSE_INFO_BLOCK_POS_GREEN1,
+  ETROBOC_COURSE_INFO_BLOCK_POS_GREEN2,
+  ETROBOC_COURSE_INFO_BLOCK_POS_END = ETROBOC_COURSE_INFO_BLOCK_POS_GREEN2,
+  ETROBOC_COURSE_INFO_MAX = ETROBOC_COURSE_INFO_BLOCK_POS_END
+};
+
 class Motor {
  public:
   double count = 0.0;
@@ -341,5 +360,15 @@ class Controller {
 
   int getVolt() { return 3; }
   int getAmp() { return 3; }
+
+  // シミュレータ用拡張API
+  /**
+   * @brief   コース情報の取得
+   * @param   コース情報取得関数用ID
+   * @return  指定されたidの情報
+   * @note    https://github.com/ETrobocon/etrobo/wiki/sim_extended_api
+   * @note    dummy Controllerでは、競技規約p26の図6-5:初期配置の例(Lコース)の配置情報を返す
+   */
+  int getCourseInfo(ETROBOC_COURSE_INFO_ID id);
 };
 #endif


### PR DESCRIPTION
## チェックリスト

- [x] clang-format した
- [x] コーディング規約に準じている
- [x] テストに通った

## 変更点
シミュレータ拡張用APIは、「競技終了通知関数」と「コース情報取得関数」の2つがある。
- Controllerクラスに「コース情報取得関数」を追加した
- 「競技終了通知関数」は、シミュレータv3.0から対応なので、現時点では追加しない
- テストコード用のdummy Controllerにも「コース情報取得関数」を追加した
dummy Controllerでは競技規約p26の図6-5: 初期配置の例(Lコース)の情報を返すようにした

## 動作確認
- APIの仕様通りに、数字カードの数字、黒ブロックに書かれた数字、全ブロックの位置を取得できることを確認した

## 参考
- シミュレータ拡張用API
https://github.com/ETrobocon/etrobo/wiki/sim_extended_api

- 競技規約p26の図6-5: 初期配置の例(Lコース)
<img width="544" alt="スクリーンショット 2020-08-23 11 42 33" src="https://user-images.githubusercontent.com/46063788/90969648-d6eb6580-e535-11ea-9cb4-fb17046629b1.png">


