### PR TITLE
close #53 白黒以外の色までライントレースする関数と任意の色までライントレースする関数を追加

### DIFF
--- a/module/LineTracer.cpp
+++ b/module/LineTracer.cpp
@@ -84,3 +84,79 @@ int LineTracer::calculateTurnValue(int speedValue, double curvatureValue, double
 
   return turnValue;
 }
+
+void LineTracer::runToColor(int targetSpeed, double pGain, double iGain, double dGain,
+                            double curvatureValue = 0.0)
+{
+  int turnValue = 0;   // 旋回値
+  int speedValue = 0;  // 直進値
+  int leftPWM = 0;     // 左モータの出力
+  int rightPWM = 0;    // 右モータの出力
+  Color currentColor = controller.getColor();
+
+  // 現在のラインの色が黒、または白の間ループ
+  while(currentColor == Color::black || currentColor == Color::white) {
+    // 前進値の計算
+    speedValue = targetSpeed;
+
+    // 旋回値の計算
+    turnValue = calculateTurnValue(speedValue, curvatureValue, 0.007, 0.005, 0.001);
+
+    // モータ出力の計算
+    if(isLeftCourse) {
+      // Leftコースの場合
+      leftPWM = speedValue + turnValue;
+      rightPWM = speedValue - turnValue;
+    } else {
+      // Rightコースの場合
+      leftPWM = speedValue - turnValue;
+      rightPWM = speedValue + turnValue;
+    }
+    // PWM値の設定
+    controller.setLeftMotorPwm(leftPWM);
+    controller.setRightMotorPwm(rightPWM);
+
+    // 現在のラインの色の取得
+    currentColor = controller.getColor();
+
+    controller.tslpTsk(4000);
+  }
+}
+
+void LineTracer::runToSpecifiedColor(Color targetColor, int targetSpeed, double pGain, double iGain,
+                                     double dGain, double curvatureValue = 0.0)
+{
+  int turnValue = 0;                           // 旋回値
+  int speedValue = 0;                          // 直進値
+  int leftPWM = 0;                             // 左モータの出力
+  int rightPWM = 0;                            // 右モータの出力
+  Color currentColor = controller.getColor();  //現在のラインの色を取得
+
+  // 現在のラインの色が指定された色でない間ループ
+  while(currentColor != targetColor) {
+    // 前進値の計算
+    speedValue = targetSpeed;
+
+    // 旋回値の計算
+    turnValue = calculateTurnValue(speedValue, curvatureValue, 0.01, 0.005, 0.01);
+
+    // モータ出力の計算
+    if(isLeftCourse) {
+      // Leftコースの場合
+      leftPWM = speedValue + turnValue;
+      rightPWM = speedValue - turnValue;
+    } else {
+      // Rightコースの場合
+      leftPWM = speedValue - turnValue;
+      rightPWM = speedValue + turnValue;
+    }
+    // PWM値の設定
+    controller.setLeftMotorPwm(leftPWM);
+    controller.setRightMotorPwm(rightPWM);
+
+    // 現在のラインの色の取得
+    currentColor = controller.getColor();
+
+    controller.tslpTsk(4000);
+  }
+}

--- a/module/LineTracer.cpp
+++ b/module/LineTracer.cpp
@@ -100,7 +100,7 @@ void LineTracer::runToColor(int targetSpeed, double pGain, double iGain, double 
     speedValue = targetSpeed;
 
     // 旋回値の計算
-    turnValue = calculateTurnValue(speedValue, curvatureValue, 0.007, 0.005, 0.001);
+    turnValue = calculateTurnValue(speedValue, curvatureValue, pGain, iGain, dGain);
 
     // モータ出力の計算
     if(isLeftCourse) {
@@ -138,7 +138,7 @@ void LineTracer::runToSpecifiedColor(Color targetColor, int targetSpeed, double 
     speedValue = targetSpeed;
 
     // 旋回値の計算
-    turnValue = calculateTurnValue(speedValue, curvatureValue, 0.01, 0.005, 0.01);
+    turnValue = calculateTurnValue(speedValue, curvatureValue, pGain, iGain, dGain);
 
     // モータ出力の計算
     if(isLeftCourse) {

--- a/module/LineTracer.h
+++ b/module/LineTracer.h
@@ -60,7 +60,7 @@ class LineTracer {
                          double dGain, double curvaturePGain = 1.2, double curvatureIGain = 1.8,
                          double curvatureDGain = 0.0);
 
-  /** 白黒以外までまでライントレースする。
+  /** 白黒以外の色までライントレースする。
    *  @param targetSpeed [目標スピード]
    *  @param pGain [カラーセンサーの値を用いたPID制御のPゲイン]
    *  @param iGain [カラーセンサーの値を用いたPID制御のIゲイン]

--- a/module/LineTracer.h
+++ b/module/LineTracer.h
@@ -60,6 +60,28 @@ class LineTracer {
                          double dGain, double curvaturePGain = 1.2, double curvatureIGain = 1.8,
                          double curvatureDGain = 0.0);
 
+  /** 白黒以外までまでライントレースする。
+   *  @param targetSpeed [目標スピード]
+   *  @param pGain [カラーセンサーの値を用いたPID制御のPゲイン]
+   *  @param iGain [カラーセンサーの値を用いたPID制御のIゲイン]
+   *  @param dGain [カラーセンサーの値を用いたPID制御のDゲイン]
+   *  @param curvatureValue [曲率(直進時は、0.0)]
+   *  @param isLeftCourse_ [Leftコースである場合True]
+   */
+  void runToColor(int targetSpeed, double pGain, double iGain, double dGain, double curvatureValue);
+
+  /** 任意の色までライントレースする。
+   *  @param lineColor [指定する色]
+   *  @param targetSpeed [目標スピード]
+   *  @param pGain [カラーセンサーの値を用いたPID制御のPゲイン]
+   *  @param iGain [カラーセンサーの値を用いたPID制御のIゲイン]
+   *  @param dGain [カラーセンサーの値を用いたPID制御のDゲイン]
+   *  @param curvatureValue [曲率(直進時は、0.0)]
+   *  @param isLeftCourse_ [Leftコースである場合True]
+   */
+  void runToSpecifiedColor(Color lineColor, int targetSpeed, double pGain, double iGain,
+                           double dGain, double curvatureValue);
+
  private:
   Controller& controller;
   int targetBrightness;


### PR DESCRIPTION
## チェックリスト
- [x] clang-format した
- [x] コーディング規約に準じている
- [x] テストに通った

## 変更点

- 白黒以外の色までライントレースする関数(引数は目標スピード,pGain,iGain,dGain,曲率,エッジ、戻り値はなし) を追加した
- 任意の色までライントレースする関数(引数は色,目標スピードpGain,iGain,dGain,曲率,エッジ、戻り値はなし) を追加した

## 実機テストの結果（実機テストが必要な場合）

- 白黒以外の色までライントレース
https://photos.app.goo.gl/es9Jwwe5KuTTTu3t6
- 任意の色までライントレース(赤)
https://photos.app.goo.gl/WtQNpUhceQnTbtty6
- 任意の色までライントレース(緑)
https://photos.app.goo.gl/neMeCdroSMvTcUtF9
- 任意の色までライントレース(青)
https://photos.app.goo.gl/788FYJnkWNNEGgpf9
- 任意の色までライントレース(黄色)
https://photos.app.goo.gl/AqqyzS4XHCSNRWGs8