### PR TITLE
commit時に自動でclang-formatするシェルスクリプト

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+STAGED_FILES=$(git diff --diff-filter=d --staged --name-only)
+
+echo "$STAGED_FILES" | grep -e '\(.*\).cpp$' -e '\(.*\).h$' | while read -r file; do
+  clang-format -i -style=file "${file}"
+  git add "${file}"
+done
+


### PR DESCRIPTION
## チェックリスト

- [ ] clang-format した
- [ ] コーディング規約に準じている
- [ ] テストに通った

## 変更点

- 新しく`pre-commit`を作った．
- これを使うことで人手によるミスが防げると思います．
- これは，`XXX.c`ファイルはフォーマットしません．したい場合は書いてあるやつを参考に追加してください．
- これを使うためには，ローカル環境に`clang-format`がないとだめです．

### ざっくりとした説明
1. `git diff`で変更したファイル名だけ取得（rmしたやつは取らない）
2. 正規表現を使って，変更したファイルが`XXX.cpp`か`XXX.h`だったら`clang-format`する．
3. ステージング後にした変更は`commit`に反映されないので，再ステージング．

## 使い方
- 以下のコマンドをリポジトリ直下で実行．
```
git config core.hooksPath .githooks
chmod a+x .githooks/pre-commit
```
