### PR TITLE
close #73 シミュレータ用拡張APIの競技終了通知関数をControllerに追加

### DIFF
--- a/module/EtRobocon2020.cpp
+++ b/module/EtRobocon2020.cpp
@@ -30,4 +30,7 @@ void EtRobocon2020::start()
   // ノーマルコースの走行開始
   NormalCourse normalCourse(controller, isLeftCourse, targetBrightness);
   normalCourse.runNormalCourse();
+
+  // 競技終了通知を送信する
+  controller.notifyCompleted();
 }

--- a/module/api/Controller.cpp
+++ b/module/api/Controller.cpp
@@ -344,3 +344,8 @@ int Controller::getCourseInfo(ETROBOC_COURSE_INFO_ID id)
 {
   return ETRoboc_getCourceInfo(id);
 }
+
+void Controller::notifyCompleted(void)
+{
+  ETRoboc_notifyCompletedToSimulator();
+}

--- a/module/api/Controller.h
+++ b/module/api/Controller.h
@@ -87,7 +87,7 @@ class Controller {
   void resetArmMotorCount();
   void stopLiftMotor();
   void steer(int power, int turnRatio);
-  
+
   // シミュレータ用拡張API
   /**
    * @brief   コース情報の取得
@@ -96,7 +96,12 @@ class Controller {
    * @note    https://github.com/ETrobocon/etrobo/wiki/sim_extended_api
    */
   int getCourseInfo(ETROBOC_COURSE_INFO_ID id);
-  
+
+  /**
+   * @brief   競技終了通知をシミュレータに送信する
+   */
+  void notifyCompleted(void);
+
  private:
   HsvStatus hsv;
   Motor liftMotor;

--- a/test/dummy/Controller.cpp
+++ b/test/dummy/Controller.cpp
@@ -40,3 +40,5 @@ int Controller::getCourseInfo(ETROBOC_COURSE_INFO_ID id)
       return 0;
   }
 }
+
+void Controller::notifyCompleted(void) {}

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -370,5 +370,11 @@ class Controller {
    * @note    dummy Controllerでは、競技規約p26の図6-5:初期配置の例(Lコース)の配置情報を返す
    */
   int getCourseInfo(ETROBOC_COURSE_INFO_ID id);
+
+  /**
+   * @brief   競技終了通知をシミュレータに送信する
+   * @note    dummy Contoellerでは、何もしない
+   */
+  void notifyCompleted(void);
 };
 #endif


### PR DESCRIPTION
## チェックリスト

- [x] clang-format した
- [x] コーディング規約に準じている
- [x] テストに通った

## 変更点

- Controllerクラスに、シミュレータ用拡張APIの競技終了通知関数を追加した
- EtRobocon2020のstart関数で、最後に競技終了通知を送信するようにした
- dummy Controllerにも、シミュレータ用拡張APIの競技終了通知関数を追加した。ただし、dummyでは何もしない

## 確認
- シミュレータで実行したとき、プログラムの最後に「SHUTDOWN」と表示されるようになった
