### PR TITLE
close #58 Rotationクラスの精度の改善

### DIFF
--- a/module/Filter.cpp
+++ b/module/Filter.cpp
@@ -38,37 +38,3 @@ double Filter::complementaryFilter(double heavyValue, double lightValue, double 
 {
   return rate * heavyValue + (1 - rate) * lightValue;
 }
-
-void Filter::rotationFilterSet(int fancName, bool clockwise)
-{
-  //回頭の時の基準値をセット
-  if(fancName == rotateFunc) {
-    if(clockwise)
-      filterData = { 1.2453, 1.128, 1.538, 1.237 };  //時計回り
-    else
-      filterData = { 1.1748, 1.097, 1.368, 1.17 };  //反時計回り
-    //ピボットターン(前)の時の基準値をセット
-  } else if(fancName == pivotTurnFunc) {
-    if(clockwise)
-      filterData = { 1.0, 1.0, 0.96, 1.01 };  //時計回り
-    else
-      filterData = { 0.98, 1.0, 0.98, 0.98 };  //反時計回り
-    //ピボットターン(後)の時の基準値をセット
-  } else if(fancName == pivotTurnBackFunc) {
-    if(clockwise)
-      filterData = { 1.01, 0.97, 1.053, 1.06 };  //時計回り
-    else
-      filterData = { 1.05, 0.98, 1.08, 1.075 };  //反時計回り
-  }
-}
-
-double Filter::rotationFilter(double Angle, double targetAngle, int pwm)
-{
-  double filterValue = filterData.Phalf_Ahalf
-                       + (filterData.Pmax_Ahalf - filterData.Phalf_Ahalf) * (pwm - 50) / 50
-                       - (filterData.Phalf_Ahalf - filterData.Phalf_Amax) * (targetAngle - 90) / 90
-                       - ((filterData.Pmax_Ahalf - filterData.Pmax_Amax)
-                          - (filterData.Phalf_Ahalf - filterData.Phalf_Amax))
-                             * (pwm - 50) / 50 * (targetAngle - 90) / 90;
-  return filterValue * Angle;
-}

--- a/module/Filter.h
+++ b/module/Filter.h
@@ -6,30 +6,15 @@
 #ifndef FILTER_H
 #define FILTER_H
 
-#define rotateFunc 0
-#define pivotTurnFunc 1
-#define pivotTurnBackFunc 2
-struct rotationFilterData {
-  //以下の4つの補正値を基準にしてrotationFilterの補正値を求める
-  double Phalf_Ahalf;  // モーターパワー50で90度回転するときの補正値
-  double Phalf_Amax;   // モーターパワー50で180度回転するときの補正値
-  double Pmax_Ahalf;   // モーターパワー100で90度回転するときの補正値
-  double Pmax_Amax;    // モーターパワー100で180度回転するときの補正値
-};
-
 class Filter {
  private:
   double preValue;
-  rotationFilterData filterData = { 1, 1, 1, 1 };
 
  public:
   Filter();
   void reset();
   double lowPassFilter(double value, double rate = 0.9);
   double complementaryFilter(double heavyValue, double lightValue, double rate = 0.94);
-
-  void rotationFilterSet(int funcName, bool clockwise);
-  double rotationFilter(double Angle, double targetAngle, int pwm);
 };
 
 #endif

--- a/module/NormalCourse.cpp
+++ b/module/NormalCourse.cpp
@@ -40,7 +40,7 @@ void NormalCourse::runNormalCourse()
        * 進む距離，目標スピード，曲率，ターンpid
        * 曲率は、直進のとき0.0を指定する
        */
-= { {
+      = { {
           { 730, baseSpeed, 0.0, { 0.5, 0.005, 0.2 } },             // 第1区間
           { 1000, baseSpeed, 0.003226, { 0.55, 0.005, 1.5 } },      // 第2区間
           { 290, baseSpeed, 0.0, { 0.2, 0.005, 0.01 } },            // 第3区間
@@ -89,7 +89,7 @@ void NormalCourse::runNormalCourse()
     lineTracer.run(ncp);
   }
   Rotation rotation(controller);
-  rotation.pivotTurn(90, isLeftCourse, 48);
+  rotation.rotate(90, isLeftCourse);
 }
 
 /**

--- a/module/Rotation.cpp
+++ b/module/Rotation.cpp
@@ -6,61 +6,47 @@
 
 #include "Rotation.h"
 
-Rotation::Rotation(Controller& controller_)
-  : Radius(45.0), distance(), filter(), controller(controller_)
-{
-}
+using namespace std;
 
-void Rotation::rotate(double angle, bool clockwise, int pwm)
-{
-  double left_pwm = clockwise ? pwm : -pwm;
-  double right_pwm = clockwise ? -pwm : pwm;
-  filter.rotationFilterSet(rotateFunc, clockwise);
-  this->run(angle, left_pwm, right_pwm);
-}
+Rotation::Rotation(Controller& controller_) : distance(), controller(controller_) {}
 
-void Rotation::pivotTurn(double angle, bool clockwise, int pwm)
-{
-  int left_pwm = clockwise ? pwm : 0;
-  int right_pwm = clockwise ? 0 : pwm;
-  filter.rotationFilterSet(pivotTurnFunc, clockwise);
-  this->run(angle, left_pwm, right_pwm);
-}
-
-void Rotation::pivotTurnBack(double angle, bool clockwise, int pwm)
-{
-  int left_pwm = clockwise ? 0 : -pwm;
-  int right_pwm = clockwise ? -pwm : 0;
-  filter.rotationFilterSet(pivotTurnBackFunc, clockwise);
-  this->run(angle, left_pwm, right_pwm);
-}
-
-void Rotation::run(double angle, double left_pwm, double right_pwm)
+void Rotation::rotate(int angle, bool clockwise, int pwm)
 {
   // angleの絶対値をとる
-  angle = std::abs(angle);
-  int pwm = std::abs(left_pwm) > std::abs(right_pwm) ? std::abs(left_pwm) : std::abs(right_pwm);
+  angle = abs(angle);
+  int leftSign = clockwise ? 1 : -1;
+  int rightSign = clockwise ? -1 : 1;
+  double targetAngle = calculate(angle);
+  int LeftPwm, RightPwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double leftAngleRate, rightAngleRate;  //現在のタイヤの回転比率[0.0~1.0]
   controller.resetMotorCount();
 
-  double motorAngle
-      = this->calculate(controller.getLeftMotorCount(), controller.getRightMotorCount());
+  // 両輪が止まるまでループ
+  while(leftSign != 0 || rightSign != 0) {
+    leftAngleRate = 1 - abs(controller.getLeftMotorCount()) / targetAngle;
+    rightAngleRate = 1 - abs(controller.getRightMotorCount()) / targetAngle;
+    LeftPwm
+        = pwm * leftAngleRate > minPwm ? (int)(pwm * leftAngleRate * leftSign) : minPwm * leftSign;
+    RightPwm = pwm * rightAngleRate > minPwm ? (int)(pwm * rightAngleRate * rightSign)
+                                             : minPwm * rightSign;
 
-  // 指定した角度回転するまでループ
-  while(filter.rotationFilter(motorAngle, angle, pwm) < angle) {
-    controller.setLeftMotorPwm(left_pwm);
-    controller.setRightMotorPwm(right_pwm);
+    controller.setLeftMotorPwm(LeftPwm);
+    controller.setRightMotorPwm(RightPwm);
     controller.tslpTsk(4000);
 
-    motorAngle = this->calculate(controller.getLeftMotorCount(), controller.getRightMotorCount());
+    if(abs(controller.getLeftMotorCount()) >= targetAngle) {
+      leftSign = 0;
+    }
+    if(abs(controller.getRightMotorCount()) >= targetAngle) {
+      rightSign = 0;
+    }
   }
   controller.stopMotor();
 }
 
-double Rotation::calculate(const int leftAngle, const int rightAngle)
+double Rotation::calculate(int Angle)
 {
-  // 両輪の回転角から回転角度を取得
   // @see docs/Odometry/odometry.pdf
   const double transform = 2.0 * Radius / Tread;
-  double WheelAngle = (std::abs(leftAngle) + std::abs(rightAngle)) / 2;
-  return transform * WheelAngle;
+  return Angle / transform;
 }

--- a/module/Rotation.cpp
+++ b/module/Rotation.cpp
@@ -16,37 +16,37 @@ void Rotation::rotate(int angle, bool clockwise, int pwm)
   angle = abs(angle);
   int leftSign = clockwise ? 1 : -1;
   int rightSign = clockwise ? -1 : 1;
-  double targetAngle = calculate(angle);
+  double targetMotorCount = calculate(angle);
   int LeftPwm, RightPwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
-  double leftAngleRate, rightAngleRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double leftCountRate, rightCountRate;  //現在のタイヤの回転比率[0.0~1.0]
   controller.resetMotorCount();
 
   // 両輪が止まるまでループ
   while(leftSign != 0 || rightSign != 0) {
-    leftAngleRate = 1 - abs(controller.getLeftMotorCount()) / targetAngle;
-    rightAngleRate = 1 - abs(controller.getRightMotorCount()) / targetAngle;
+    leftCountRate = 1 - abs(controller.getLeftMotorCount()) / targetMotorCount;
+    rightCountRate = 1 - abs(controller.getRightMotorCount()) / targetMotorCount;
     LeftPwm
-        = pwm * leftAngleRate > minPwm ? (int)(pwm * leftAngleRate * leftSign) : minPwm * leftSign;
-    RightPwm = pwm * rightAngleRate > minPwm ? (int)(pwm * rightAngleRate * rightSign)
+        = pwm * leftCountRate > minPwm ? (int)(pwm * leftCountRate * leftSign) : minPwm * leftSign;
+    RightPwm = pwm * rightCountRate > minPwm ? (int)(pwm * rightCountRate * rightSign)
                                              : minPwm * rightSign;
 
     controller.setLeftMotorPwm(LeftPwm);
     controller.setRightMotorPwm(RightPwm);
     controller.tslpTsk(4000);
 
-    if(abs(controller.getLeftMotorCount()) >= targetAngle) {
+    if(abs(controller.getLeftMotorCount()) >= targetMotorCount) {
       leftSign = 0;
     }
-    if(abs(controller.getRightMotorCount()) >= targetAngle) {
+    if(abs(controller.getRightMotorCount()) >= targetMotorCount) {
       rightSign = 0;
     }
   }
   controller.stopMotor();
 }
 
-double Rotation::calculate(int Angle)
+double Rotation::calculate(int angle)
 {
   // @see docs/Odometry/odometry.pdf
   const double transform = 2.0 * Radius / Tread;
-  return Angle / transform;
+  return angle / transform;
 }

--- a/module/Rotation.h
+++ b/module/Rotation.h
@@ -18,11 +18,11 @@ class Rotation {
   static constexpr int minPwm = 10;       // モーターパワーの最小値
 
   /**
-   *  @brief 指定角度回頭したときの片輪の回転角度を算する
+   *  @brief 指定角度回頭したときの片輪の回転角度を計算する
    *  @param Angle [走行体が回頭する角度[deg]]
    *  @return 片輪の回転角度(回転方向に関わらず正の数)
    */
-  double calculate(int Angle);
+  double calculate(int angle);
 
  public:
   /**　コンストラクタ
@@ -34,7 +34,7 @@ class Rotation {
    *  @brief 走行体を回頭させる
    *  @param angle [回頭角度]
    *  @param clockwise [回転方向(Trueが時計回り)]
-   *  @param pwm [モーターパワー]
+   *  @param pwm [モーターパワー(PWM1の最大値）]
    */
   void rotate(int angle, bool clockwise, int pwm = 100);
 };

--- a/module/Rotation.h
+++ b/module/Rotation.h
@@ -34,7 +34,7 @@ class Rotation {
    *  @brief 走行体を回頭させる
    *  @param angle [回頭角度]
    *  @param clockwise [回転方向(Trueが時計回り)]
-   *  @param pwm [モーターパワー(PWM1の最大値）]
+   *  @param pwm [モーターパワー(PWMの最大値）]
    */
   void rotate(int angle, bool clockwise, int pwm = 100);
 };

--- a/module/Rotation.h
+++ b/module/Rotation.h
@@ -7,24 +7,22 @@
 #define ROTATION_H
 
 #include "Distance.h"
-#include "Filter.h"
 #include <cmath>
 
 class Rotation {
  private:
-  const double Radius;                    //車輪の半径[mm]
-  static constexpr double Tread = 140.0;  //走行体のトレッド幅（両輪の間の距離）[mm]
   Distance distance;
-  Filter filter;
   Controller& controller;
+  static constexpr double Radius = 45.0;  //車輪の半径[mm]
+  static constexpr double Tread = 140.0;  //走行体のトレッド幅（両輪の間の距離）[mm]
+  static constexpr int minPwm = 10;       // モーターパワーの最小値
 
   /**
-   *  @brief 走行体を指定されたように回転させる
-   *  @param angle [回転角度]
-   *  @param left_pwm [左車輪のモーターパワー]
-   *  @param right_pwm [右車輪のモーターパワー]
+   *  @brief 指定角度回頭したときの片輪の回転角度を算する
+   *  @param Angle [走行体が回頭する角度[deg]]
+   *  @return 片輪の回転角度(回転方向に関わらず正の数)
    */
-  void run(double angle, double left_pwm, double right_pwm);
+  double calculate(int Angle);
 
  public:
   /**　コンストラクタ
@@ -38,31 +36,7 @@ class Rotation {
    *  @param clockwise [回転方向(Trueが時計回り)]
    *  @param pwm [モーターパワー]
    */
-  void rotate(double angle, bool clockwise, int pwm = 50);
-
-  /**
-   *  @brief 走行体を軸足回転させる
-   *  @param angle [軸足回転角度]
-   *  @param clockwise [回転方向(Trueが時計回り)]
-   *  @param pwm [モーターパワー]
-   */
-  void pivotTurn(double angle, bool clockwise, int pwm = 30);
-
-  /**
-   *  @brief 走行体をバックで軸足回転させる
-   *  @param angle [軸足回転角度]
-   *  @param clockwise [回転方向(Trueが時計回り)]
-   *  @param pwm [モーターパワー]
-   */
-  void pivotTurnBack(double angle, bool clockwise, int pwm = 30);
-
-  /**
-   *  @brief 回転したときの角度を求める
-   *  @param leftAngle [左車輪の回頭角度[deg]]
-   *  @param rightAngle [右車輪の回頭角度[deg]]
-   *  @return 回転角度(回転方向に関わらず正の数)
-   */
-  double calculate(const int leftAngle, const int rightAngle);
+  void rotate(int angle, bool clockwise, int pwm = 100);
 };
 
 #endif

--- a/test/RotationTest.cpp
+++ b/test/RotationTest.cpp
@@ -7,75 +7,74 @@
 #include "Controller.h"
 #include <gtest/gtest.h>
 
+using namespace std;
+
 namespace etrobocon2020_test {
-  TEST(Rotation, calculate)
-  {
-    Controller controller;
-    Rotation rotation(controller);
-    const double Radius = 45.0;
-    static constexpr double Tread = 140.0;
-    double wheelAngle = 30;
-
-    double expected = 2.0 * Radius * wheelAngle / Tread;
-
-    ASSERT_DOUBLE_EQ(expected, rotation.calculate(30, -30));
-    ASSERT_DOUBLE_EQ(expected, rotation.calculate(-30, 30));
-  }
-
   TEST(Rotation, rotate)
   {
+    constexpr double Radius = 45.0;
+    constexpr double Tread = 140.0;
+    const double transform = 2.0 * Radius / Tread;
+
     Controller controller;
     Rotation rotation(controller);
-    Filter filter;
+    double expected, actual;
+    double motorAngle;
+    bool clockwise;
 
-    double expected = 90;
-    bool clockwise = true;
+    // 45度右回頭の回頭誤差が１度未満かテスト
+    expected = 45;
+    clockwise = true;
     rotation.rotate(expected, clockwise);
-
-    filter.rotationFilterSet(rotateFunc, clockwise);
-    double actual = filter.rotationFilter(
-        rotation.calculate(controller.getLeftMotorCount(), controller.getRightMotorCount()),
-        expected, 50);
-
+    motorAngle = (abs(controller.getLeftMotorCount()) + abs(controller.getRightMotorCount())) / 2;
+    actual = transform * motorAngle;
     ASSERT_LE(expected, actual);
-    ASSERT_GE(expected + 5, actual);
+    ASSERT_GE(expected + 1.0, actual);
+
+    // 45度左回頭の回頭誤差が１度未満かテスト
+    expected = 45;
+    clockwise = false;
+    rotation.rotate(expected, clockwise);
+    motorAngle = (abs(controller.getLeftMotorCount()) + abs(controller.getRightMotorCount())) / 2;
+    actual = transform * motorAngle;
+    ASSERT_LE(expected, actual);
+    ASSERT_GE(expected + 1.0, actual);
+
+    // 90度右回頭の回頭誤差が１度未満かテスト
+    expected = 90;
+    clockwise = true;
+    rotation.rotate(expected, clockwise);
+    motorAngle = (abs(controller.getLeftMotorCount()) + abs(controller.getRightMotorCount())) / 2;
+    actual = transform * motorAngle;
+    ASSERT_LE(expected, actual);
+    ASSERT_GE(expected + 1.0, actual);
+
+    // 90度左回頭の回頭誤差が１度未満かテスト
+    expected = 90;
+    clockwise = false;
+    rotation.rotate(expected, clockwise);
+    motorAngle = (abs(controller.getLeftMotorCount()) + abs(controller.getRightMotorCount())) / 2;
+    actual = transform * motorAngle;
+    ASSERT_LE(expected, actual);
+    ASSERT_GE(expected + 1.0, actual);
+
+    // // 180度右回頭の回頭誤差が１度未満かテスト
+    expected = 180;
+    clockwise = true;
+    rotation.rotate(expected, clockwise);
+    motorAngle = (abs(controller.getLeftMotorCount()) + abs(controller.getRightMotorCount())) / 2;
+    actual = transform * motorAngle;
+    ASSERT_LE(expected, actual);
+    ASSERT_GE(expected + 1.0, actual);
+
+    // 180度右回頭の回頭誤差が１度未満かテスト
+    expected = 180;
+    clockwise = false;
+    rotation.rotate(expected, clockwise);
+    motorAngle = (abs(controller.getLeftMotorCount()) + abs(controller.getRightMotorCount())) / 2;
+    actual = transform * motorAngle;
+    ASSERT_LE(expected, actual);
+    ASSERT_GE(expected + 1.0, actual);
   }
 
-  TEST(Rotation, pivotTurn)
-  {
-    Controller controller;
-    Rotation rotation(controller);
-    Filter filter;
-
-    double expected = 90;
-    bool clockwise = true;
-    rotation.pivotTurn(expected, clockwise);
-
-    filter.rotationFilterSet(pivotTurnFunc, clockwise);
-    double actual = filter.rotationFilter(
-        rotation.calculate(controller.getLeftMotorCount(), controller.getRightMotorCount()),
-        expected, 30);
-
-    ASSERT_LE(expected, actual);
-    ASSERT_GE(expected + 5, actual);
-  }
-
-  TEST(Rotation, pivotTurnBack)
-  {
-    Controller controller;
-    Rotation rotation(controller);
-    Filter filter;
-
-    double expected = 90;
-    bool clockwise = true;
-    rotation.pivotTurnBack(expected, clockwise);
-
-    filter.rotationFilterSet(pivotTurnBackFunc, clockwise);
-    double actual = filter.rotationFilter(
-        rotation.calculate(controller.getLeftMotorCount(), controller.getRightMotorCount()),
-        expected, 30);
-
-    ASSERT_LE(expected, actual);
-    ASSERT_GE(expected + 5, actual);
-  }
 }  // namespace etrobocon2020_test

--- a/test/RotationTest.cpp
+++ b/test/RotationTest.cpp
@@ -67,7 +67,7 @@ namespace etrobocon2020_test {
     ASSERT_LE(expected, actual);
     ASSERT_GE(expected + 1.0, actual);
 
-    // 180度右回頭の回頭誤差が１度未満かテスト
+    // 180度左回頭の回頭誤差が１度未満かテスト
     expected = 180;
     clockwise = false;
     rotation.rotate(expected, clockwise);

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -55,7 +55,7 @@ class Motor {
     // std::cout << count << std::endl;
   };
   void stop(){};
-  void reset(){};
+  void reset() { count = 0; };
   void setBrake(bool isBrake){};
 };
 


### PR DESCRIPTION
## チェックリスト

- [x] clang-format した
- [x] コーディング規約に準じている
- [x] テストに通った

## 変更点

- 回頭角度に応じてPWMを小さくして、緩やかに停止するようにした
- 仮に作っていたフィルタを削除した
- 不要なピボットターンを削除した
- テスト用のcontrollerクラスresetMotorの処理を追加

## 実機テストの結果
- [回頭の様子](https://photos.app.goo.gl/v5Nq8iwHL8ddp3229)
- 45度回頭したときの10回平均

| | 平均回頭角度[°] | 平均回頭時間[sec] |
---|:---:|:---: 
| 変更前(PWM10) | 45.55 | 1.38 |
| 変更前(PWM20) | 46.40 | 0.68 |
| 変更前(PWM30) | 48.55 | 0.48 |
| **変更後** | **45.80** | **0.40** |


### 誤差率の計算式

誤差率 = 1.78%