### PR TITLE
close #75 直進の精度を改善、曲率補正+緩やかな発進・停止

### DIFF
--- a/module/Curvature.h
+++ b/module/Curvature.h
@@ -21,7 +21,7 @@ class Curvature {
 
  public:
   Curvature(double targetCurvature, double Kp, double Ki, double Kd);
-  double control(int leftAngle, int rightAngle, int velocity = 600);
+  double control(int leftAngle, int rightAngle, int velocity = 436);
 };
 
 #endif

--- a/module/MoveStraight.cpp
+++ b/module/MoveStraight.cpp
@@ -5,32 +5,46 @@
  **/
 #include "MoveStraight.h"
 
-MoveStraight::MoveStraight(Controller& controller_) : controller(controller_) {}
-
-void MoveStraight::moveTo(int destination, unsigned int pwm)
+MoveStraight::MoveStraight(Controller& controller_)
+  : controller(controller_), odometer(), curvature(0.0, 4.0, 1.0, 0.0)
 {
-  // 現在の位置
-  int presPos
-      = odometer.getDistance(controller.getLeftMotorCount(), controller.getRightMotorCount());
+}
 
-  // 目的位置
-  int goal = presPos + destination;
+void MoveStraight::moveTo(int destination, unsigned int maxPwm)
+{
+  controller.resetMotorCount();
 
-  if(destination > 0) {      // 目的位置が走行体より前方
-    while(presPos < goal) {  // 目的位置にたどり着くまで前進
-      controller.setLeftMotorPwm(pwm);
-      controller.setRightMotorPwm(pwm);
+  int presPos = 0;
+  int correction = 0;  // 曲率PIDによる補正値
+  int currentPwm = 0;
+
+  if(destination > 0) {             // 目的位置が走行体より前方
+    while(presPos < destination) {  // 目的位置にたどり着くまで前進
+      currentPwm = calcPwm(presPos, destination, maxPwm);
+      correction
+          = curvature.control(controller.getLeftMotorCount(), controller.getRightMotorCount());
+
+      controller.setLeftMotorPwm(currentPwm + correction);
+      controller.setRightMotorPwm(currentPwm - correction);
+
       presPos
           = odometer.getDistance(controller.getLeftMotorCount(), controller.getRightMotorCount());
+
       controller.tslpTsk(2000);  // 実機では4000に
     }
   } else {
     //目的位置が走行体より後方
-    while(presPos > goal) {  // 目的位置にたどり着くまで後退
-      controller.setLeftMotorPwm(-pwm);
-      controller.setRightMotorPwm(-pwm);
+    while(presPos > destination) {  // 目的位置にたどり着くまで後退
+      currentPwm = calcPwm(presPos, destination, maxPwm);
+      correction
+          = curvature.control(controller.getLeftMotorCount(), controller.getRightMotorCount());
+
+      controller.setLeftMotorPwm(-(currentPwm + correction));
+      controller.setRightMotorPwm(-(currentPwm - correction));
+
       presPos
           = odometer.getDistance(controller.getLeftMotorCount(), controller.getRightMotorCount());
+
       controller.tslpTsk(2000);  // 実機では4000に
     }
   }
@@ -41,12 +55,15 @@ void MoveStraight::moveTo(int destination, unsigned int pwm)
 
 void MoveStraight::moveWhileBW(unsigned int pwm)
 {
+  int correction = 0;  // 曲率PIDによる補正値
   Color col;
+
   while((col = controller.getColor()) == Color::black
         || col == Color::white)  //色評価変数colが黒か白の場合は継続
   {
-    controller.setLeftMotorPwm(pwm);
-    controller.setRightMotorPwm(pwm);
+    correction = curvature.control(controller.getLeftMotorCount(), controller.getRightMotorCount());
+    controller.setLeftMotorPwm(pwm + correction);
+    controller.setRightMotorPwm(pwm - correction);
     controller.tslpTsk(2000);  // 実機では4000に
   }
   controller.stopMotor();
@@ -54,11 +71,27 @@ void MoveStraight::moveWhileBW(unsigned int pwm)
 
 void MoveStraight::moveTo(Color destColor, unsigned int pwm)
 {
+  int correction = 0;  // 曲率PIDによる補正値
+
   while(controller.getColor() != destColor)  //目的の色まで達するまで継続
   {
-    controller.setLeftMotorPwm(pwm);
-    controller.setRightMotorPwm(pwm);
+    correction = curvature.control(controller.getLeftMotorCount(), controller.getRightMotorCount());
+    controller.setLeftMotorPwm(pwm + correction);
+    controller.setRightMotorPwm(pwm - correction);
     controller.tslpTsk(2000);  // 実機では4000に
   }
   controller.stopMotor();
+}
+
+int MoveStraight::calcPwm(int presPos, int destination, int maxPwm)
+{
+  int minPwm = 10;
+  if(maxPwm < minPwm) minPwm = maxPwm;
+
+  // 上に凸の放物線の方程式より、走行距離に応じてpwmを計算する。放物線は、次の点を通る。
+  // (0, minPwm) (destination/2, maxPwm) (destination, minPwm)
+  double pwm = 4 * (minPwm - maxPwm) * (presPos - destination / 2) * (presPos - destination / 2);
+  pwm = pwm / (destination * destination) + maxPwm;
+
+  return static_cast<int>(pwm);
 }

--- a/module/MoveStraight.cpp
+++ b/module/MoveStraight.cpp
@@ -88,10 +88,12 @@ int MoveStraight::calcPwm(int presPos, int destination, int maxPwm)
   int minPwm = 10;
   if(maxPwm < minPwm) minPwm = maxPwm;
 
-  // 上に凸の放物線の方程式より、走行距離に応じてpwmを計算する。放物線は、次の点を通る。
-  // (0, minPwm) (destination/2, maxPwm) (destination, minPwm)
-  double pwm = 4 * (minPwm - maxPwm) * (presPos - destination / 2) * (presPos - destination / 2);
-  pwm = pwm / (destination * destination) + maxPwm;
+  // 二次関数の式 y = a(x - p)^2 + q を利用して、走行距離に応じてPWM値を放物線のように変化させる。
+  // 放物線は、次の点を通る。(0, minPwm) (destination/2, maxPwm) (destination, minPwm)
+  // pwm = a(presPos - destination/2)^2 + maxPwm
+  // a = 4(minPwm - maxPwm) / destination^2
+  const double a = 4.0 * (minPwm - maxPwm) / (destination * destination);
+  double pwm = a * (presPos - destination / 2) * (presPos - destination / 2) + maxPwm;
 
   return static_cast<int>(pwm);
 }

--- a/module/MoveStraight.h
+++ b/module/MoveStraight.h
@@ -8,45 +8,48 @@
 
 #define _USE_MATH_DEFINES
 #include "Controller.h"
+#include "Curvature.h"
 #include "Distance.h"
 #include <cmath>
 
 class MoveStraight {
  public:
   /**
-   * コンストラクタ
    * @brief MoveStraightクラスのコンストラクタ
    */
 
   MoveStraight(Controller& controller_);
   /**
-   * 任意の距離だけ直線移動する
-   *
-   * @brief
+   * @brief 任意の距離だけ直線移動する
    * @param destination 移動距離（mm, 正で前進・負で後退）
-   * @param pwm モータ出力
+   * @param maxPwm モータ出力の最大値
    */
-  void moveTo(int destination, unsigned int pwm = 30);
+  void moveTo(int destination, unsigned int maxPwm = 30);
 
   /**
-   * 白黒以外まで直進する
-   * @brief
+   * @brief 白黒以外まで直進する
    * @param pwm モータ出力
    */
   void moveWhileBW(unsigned int pwm = 30);
 
   /**
-   * 任意の色まで直進する
-   *
-   * @brief オーバーロードしてみた
+   * @brief 任意の色まで直進する
    * @param destColor 直進して目指す色
    * @param pwm モータ出力
    */
   void moveTo(Color destColor, unsigned int pwm = 30);
 
  private:
-  Distance odometer;       // 距離計
   Controller& controller;  // 参照型Controllerクラス
+  Curvature curvature;
+  Distance odometer;  // 距離計
+  /**
+   * @brief 放物線の方程式から、走行距離に応じてminPwm→maxPwm→minPwmとなるようなpwm値を計算する
+   * @param presPos     現在位置
+   * @param destination 移動距離
+   * @param maxPwm      モータ出力の最大値
+   */
+  int calcPwm(int presPos, int destination, int maxPwm);
 };
 
 #endif


### PR DESCRIPTION
## チェックリスト

- [x] clang-format した
- [x] コーディング規約に準じている
- [x] テストに通った

## 変更点

- 直進時に、曲率を用いてPWM値を補正する
- 緩やかに発進・停止するために、指定距離だけ直進する関数(moveTo関数)は、走行距離から走行体に設定するPWM値を計算する。PWM値は以下のグラフように変換する。
- Curvatureクラスの走行体の速度が去年のままだったため、今年の速度に変更  

<img width="361" alt="図1" src="https://user-images.githubusercontent.com/46063788/96868602-4683bf80-14a9-11eb-8891-510a9d09a5a4.png">
<img width="362" alt="図2" src="https://user-images.githubusercontent.com/46063788/96868607-48e61980-14a9-11eb-8062-2589eeed3ed7.png">
<img width="361" alt="図3" src="https://user-images.githubusercontent.com/46063788/96868631-50a5be00-14a9-11eb-8902-80c516cd8586.png">
<img width="361" alt="図4" src="https://user-images.githubusercontent.com/46063788/96868639-53081800-14a9-11eb-93fc-0dad6857e835.png">
