### PR TITLE
close #65 経路を走行体動作に変換する

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -10,6 +10,7 @@ APPL_CXXOBJS += \
     Distance.o \
     EtRobocon2020.o \
     Filter.o \
+    MotionSequencer.o \
     MoveStraight.o \
     LineTracer.o \
     NormalCourse.o \

--- a/module/BlockBingoData.cpp
+++ b/module/BlockBingoData.cpp
@@ -285,22 +285,29 @@ Direction BlockBingoData::calcNextDirection(Coordinate const& currentCoordinate,
   int xDiff = nextCoordinate.x - currentCoordinate.x;
   int yDiff = nextCoordinate.y - currentCoordinate.y;
 
-  if(xDiff == 0 && yDiff == -1) {
-    return Direction::North;
-  } else if(xDiff == 1 && yDiff == -1) {
-    return Direction::NEast;
-  } else if(xDiff == 1 && yDiff == 0) {
-    return Direction::East;
-  } else if(xDiff == 1 && yDiff == 1) {
-    return Direction::SEast;
-  } else if(xDiff == 0 && yDiff == 1) {
-    return Direction::South;
-  } else if(xDiff == -1 && yDiff == 1) {
-    return Direction::SWest;
-  } else if(xDiff == -1 && yDiff == 0) {
-    return Direction::West;
+  if(xDiff < 0) {
+    if(yDiff < 0) {
+      return Direction::NWest;
+    } else if(yDiff == 0) {
+      return Direction::West;
+    } else {
+      return Direction::SWest;
+    }
+  } else if(xDiff == 0) {
+    if(yDiff <= 0) {
+      // currentCoordinate == nextCoordinatteのときもNorthを返す
+      return Direction::North;
+    } else {
+      return Direction::South;
+    }
   } else {
-    return Direction::NWest;
+    if(yDiff < 0) {
+      return Direction::NEast;
+    } else if(yDiff == 0) {
+      return Direction::East;
+    } else {
+      return Direction::SEast;
+    }
   }
 }
 

--- a/module/BlockBingoData.cpp
+++ b/module/BlockBingoData.cpp
@@ -278,3 +278,62 @@ Color BlockBingoData::getCrossCircleColor(Coordinate coordinate)
   return isLeftCourse ? crossCircleColorL[coordinate.y / 2][coordinate.x / 2]
                       : crossCircleColorR[coordinate.y / 2][coordinate.x / 2];
 }
+
+Direction BlockBingoData::calcNextDirection(Coordinate const& currentCoordinate,
+                                            Coordinate const& nextCoordinate)
+{
+  int xDiff = nextCoordinate.x - currentCoordinate.x;
+  int yDiff = nextCoordinate.y - currentCoordinate.y;
+
+  if(xDiff == 0 && yDiff == -1) {
+    return Direction::North;
+  } else if(xDiff == 1 && yDiff == -1) {
+    return Direction::NEast;
+  } else if(xDiff == 1 && yDiff == 0) {
+    return Direction::East;
+  } else if(xDiff == 1 && yDiff == 1) {
+    return Direction::SEast;
+  } else if(xDiff == 0 && yDiff == 1) {
+    return Direction::South;
+  } else if(xDiff == -1 && yDiff == 1) {
+    return Direction::SWest;
+  } else if(xDiff == -1 && yDiff == 0) {
+    return Direction::West;
+  } else {
+    return Direction::NWest;
+  }
+}
+
+bool BlockBingoData::setBlock(Coordinate const& coordinate, Block block)
+{
+  if(coordinate.x % 2 == 0 && coordinate.y % 2 == 0) {
+    crossCircleCoordinate[coordinate.y / 2][coordinate.x / 2].block = block;
+    return true;
+  } else if(coordinate.x % 2 == 1 && coordinate.y % 2 == 1) {
+    blockCircleCoordinate[(coordinate.y - 1) / 2][(coordinate.x - 1) / 2].block = block;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+Block BlockBingoData::getBlock(Coordinate const& coordinate)
+{
+  NodeType nodeType = checkNode(coordinate);
+  if(nodeType == NodeType::crossCircle) {
+    return crossCircleCoordinate[coordinate.y / 2][coordinate.x / 2].block;
+  } else if(nodeType == NodeType::blockCircle) {
+    return blockCircleCoordinate[(coordinate.y - 1) / 2][(coordinate.x - 1) / 2].block;
+  } else {
+    return Block();
+  }
+}
+
+bool BlockBingoData::hasBlock(Coordinate const& coordinate)
+{
+  if(getBlock(coordinate).blockColor == Color::none) {
+    return false;
+  } else {
+    return true;
+  }
+}

--- a/module/BlockBingoData.h
+++ b/module/BlockBingoData.h
@@ -127,6 +127,37 @@ class BlockBingoData {
    */
   Color getCrossCircleColor(Coordinate coordinate);
 
+  /**
+   *  @brief 現在座標から見た場合の次の座標の方位を計算する
+   *  @param currentCoordinate [現在座標]
+   *  @param nextCoordinate [次の座標]
+   *  @return 現在座標から見た場合の次の座標の方位
+   */
+  Direction calcNextDirection(Coordinate const& currentCoordinate,
+                              Coordinate const& nextCoordinate);
+
+  /**
+   *  @brief 座標の交点サークルまたはブロックサークルにブロックを設定する
+   *  @param coordinate [設定先サークルの座標]
+   *  @param block      [設定するブロック]
+   *  @return ブロック設定の成否
+   */
+  bool setBlock(Coordinate const& coordinate, Block block);
+
+  /**
+   *  @brief 座標のブロックを取得する
+   *  @param coordinate [取得する座標]
+   *  @return 座標に置かれているブロック
+   */
+  Block getBlock(Coordinate const& coordinate);
+
+  /**
+   *  @brief 座標にブロックがあるかどうかを判定する
+   *  @param coordinate [判定したい座標]
+   *  @return ブロックの有無(ture=有)
+   */
+  bool hasBlock(Coordinate const& coordinate);
+
  private:
   Controller& controller;
   bool isLeftCourse;

--- a/module/MotionSequencer.cpp
+++ b/module/MotionSequencer.cpp
@@ -1,0 +1,89 @@
+#include "MotionSequencer.h"
+
+MotionSequencer::MotionSequencer(BlockBingoData& blockBingoData_) : blockBingoData(blockBingoData_)
+{
+}
+
+Direction MotionSequencer::route2MotionCommand(vector<Coordinate> const& route,
+                                               vector<MotionCommand>& motionCommandList)
+{
+  Coordinate currentCoordinate = route.front();
+  Direction currentDirection = blockBingoData.getDirection();
+  Coordinate nextCoordinate = currentCoordinate;
+  Direction nextDirection = currentDirection;
+
+  for(unsigned int i = 1; i < route.size(); i++) {
+    nextCoordinate = route[i];
+    nextDirection = blockBingoData.calcNextDirection(currentCoordinate, nextCoordinate);
+
+    // 次の座標の方向を向く
+    int rotationCount = calcRotationCount(currentDirection, nextDirection);
+    if(rotationCount > 0) {
+      // 時計回りに方向転換 MotionCommand::RTは時計回りに45°方向転換
+      for(int count = 0; count < abs(rotationCount); count++) {
+        motionCommandList.push_back(MotionCommand::RT);
+      }
+    } else if(rotationCount < 0) {
+      // 反時計回りに方向転換 MotionCommand::RTは反時計回りに45°方向転換
+      for(int count = 0; count < abs(rotationCount); count++) {
+        motionCommandList.push_back(MotionCommand::RF);
+      }
+    }
+
+    // 現在座標から次の座標へ移動する
+    NodeType currentType = blockBingoData.checkNode(currentCoordinate);
+    NodeType nextType = blockBingoData.checkNode(nextCoordinate);
+
+    // 現在座標と次の座標の種類に応じて、移動方法を切り替える
+    if(currentType == NodeType::crossCircle && nextType == NodeType::middlePoint) {
+      // 交点サークルから中点への移動
+      motionCommandList.push_back(MotionCommand::CM);
+    } else if(currentType == NodeType::crossCircle && nextType == NodeType::blockCircle) {
+      if(i == route.size() - 1 && blockBingoData.hasBlock(route.front())) {
+        // 交点サークルからブロックサークルにブロックを設置
+        motionCommandList.push_back(MotionCommand::SC);
+      } else {
+        // 交点サークルからブロックサークルのブロックを取得
+        motionCommandList.push_back(MotionCommand::GC);
+      }
+    } else if(currentType == NodeType::middlePoint && nextType == NodeType::crossCircle) {
+      // 中点から交点サークルへの移動
+      motionCommandList.push_back(MotionCommand::MC);
+    } else if(currentType == NodeType::middlePoint && nextType == NodeType::middlePoint) {
+      // 中点から中点への移動
+      motionCommandList.push_back(MotionCommand::MM);
+    } else if(currentType == NodeType::middlePoint && nextType == NodeType::blockCircle) {
+      if(i == route.size() - 1 && blockBingoData.hasBlock(route.front())) {
+        // 中点からブロックサークルにブロックを設置
+        motionCommandList.push_back(MotionCommand::SM);
+      } else {
+        // 中点からブロックサークルのブロックを取得
+        motionCommandList.push_back(MotionCommand::GM);
+      }
+    } else if(currentType == NodeType::blockCircle && nextType == NodeType::crossCircle) {
+      // ブロックサークルから交点サークルへの移動
+      motionCommandList.push_back(MotionCommand::BC);
+    } else if(currentType == NodeType::blockCircle && nextType == NodeType::middlePoint) {
+      // ブロックサークルから中点への移動
+      motionCommandList.push_back(MotionCommand::BM);
+    }
+
+    currentCoordinate = nextCoordinate;
+    currentDirection = nextDirection;
+  }
+  return nextDirection;
+}
+
+int MotionSequencer::calcRotationCount(Direction currentDirection, Direction nextDirection)
+{
+  constexpr int numDirection = 8;
+  int diffDirection = static_cast<int>(nextDirection) - static_cast<int>(currentDirection);
+
+  if(diffDirection > numDirection / 2) {
+    diffDirection -= numDirection;
+  } else if(diffDirection < -numDirection / 2) {
+    diffDirection += numDirection;
+  }
+
+  return diffDirection;
+}

--- a/module/MotionSequencer.h
+++ b/module/MotionSequencer.h
@@ -1,0 +1,45 @@
+/**
+ * @file MotionSequencer.h
+ * @brief 座標情報を機動に変換するクラス
+ * @author T.Yoshino(Mikoyaan), D.Hirayama(Kanikama)
+ **/
+
+#ifndef MOTIONSEQUENCER_H
+#define MOTIONSEQUENCER_H
+
+#include <vector>
+#include "Controller.h"
+#include "BlockBingoData.h"
+#include "Navigator.h"
+
+using std::abs;
+using std::vector;
+
+class MotionSequencer {
+ public:
+  /** コンストラクタ
+   * @param　controller_
+   * @param isLeftCourse
+   * @param blockBingoData_
+   **/
+  MotionSequencer(BlockBingoData& blockBingoData_);
+
+  /** 経路->動作命令リスト変換
+   * @param route             [経路]
+   * @param motionCommandList [動作命令リスト]
+   * @return 最終的な走行体の向き
+   **/
+  Direction route2MotionCommand(vector<Coordinate> const& route,
+                                vector<MotionCommand>& motionCommandList);
+
+ private:
+  BlockBingoData& blockBingoData;
+
+  /** 45°方向転換を行う回数と、方向転換の向き(時計回り/反時計回り)を計算する
+   * @param   currentDirection  [現在の走行体の方向]
+   * @param   nextDirection     [現在座標から見た、次の座標の方向]
+   * @return  45°方向転換を行う回数(正=時計回り,負=反時計回り)
+   **/
+  int calcRotationCount(Direction currentDirection, Direction nextDirection);
+};
+#endif  // MOTIONSEQUENCER_H

--- a/module/Navigator.cpp
+++ b/module/Navigator.cpp
@@ -1,25 +1,143 @@
 /**
  *  @file  Navigator.cpp
- *  @brief ビンゴエリアを走る
- *  @author sugaken0528
+ *  @brief 動作命令に従ってブロックビンゴエリアを走行する
+ *  @author sugaken0528, arimakaoru
  */
 
 #include "Navigator.h"
 
-Navigator::Navigator(Controller& controller_, bool isLeftCourse_, int targetBrightness_)
-  : controller(controller_), isLeftCourse(isLeftCourse_), targetBrightness(targetBrightness_)
+Navigator::Navigator(Controller& controller_, bool isLeftCourse_)
+  : controller(controller_),
+    isLeftCourse(isLeftCourse_),
+    isLeftEdge(!isLeftCourse_),
+    moveStraight(controller_),
+    lineTracer(controller_, controller_.getTargetBrightness(), !isLeftCourse_),
+    rotation(controller_)
 {
 }
 
-void Navigator::traceBingoArea(bool isRightEdge)
+void Navigator::execMotion(vector<MotionCommand> const& motionCommandList)
 {
-  LineTracer lineTracer(controller, targetBrightness, isRightEdge);
-  double pGain = 0.1;
-  double iGain = 0.005;
-  double dGain = 0.01;
-  int basespeed = 70;
-  int distance = 255;
-  // 開始位置: Lコース(x: 13.43 y: z: 12.2 rot: 180)
-  NormalCourseProperty property = { distance, basespeed, 0.0, { pGain, iGain, dGain } };
-  lineTracer.run(property);
+  for(unsigned int i = 0; i < motionCommandList.size(); i++) {
+    MotionCommand motionCommand = motionCommandList[i];
+    int countRepeated = 0;
+    switch(motionCommand) {
+      case MotionCommand::RT:
+        // 連続するRTはまとめて回頭する
+        countRepeated = countRepeatedCommand(motionCommandList, i);
+        changeDirection(abs(45 * countRepeated), true);
+        i += countRepeated - 1;
+        break;
+      case MotionCommand::RF:
+        // 連続するRFはまとめて回頭する
+        countRepeated = countRepeatedCommand(motionCommandList, i);
+        changeDirection(abs(45 * countRepeated), false);
+        i += countRepeated - 1;
+        break;
+      case MotionCommand::CM:
+        moveC2M();
+        break;
+      case MotionCommand::GC:
+        getBlockFromC();
+        break;
+      case MotionCommand::SC:
+        setBlockFromC();
+        break;
+      case MotionCommand::MC:
+        moveM2C();
+        break;
+      case MotionCommand::MM:
+        moveM2M();
+        break;
+      case MotionCommand::GM:
+        getBlockFromM();
+        break;
+      case MotionCommand::SM:
+        setBlockFromM();
+        break;
+      case MotionCommand::BC:
+        moveB2C();
+        break;
+      case MotionCommand::BM:
+        moveB2M();
+        break;
+      default:
+        break;
+    }
+    controller.tslpTsk(4000);
+  }
+}
+
+int Navigator::countRepeatedCommand(vector<MotionCommand> const& motionCommandList, int startIndex)
+{
+  MotionCommand startCommand = motionCommandList[startIndex];
+  int count = 1;
+  for(unsigned int i = startIndex + 1; i < motionCommandList.size(); i++) {
+    if(motionCommandList[i] != startCommand) break;
+    count++;
+  }
+  return count;
+}
+
+void Navigator::changeDirection(unsigned int rotationAngle, bool clockwise)
+{
+  rotation.rotate(rotationAngle, clockwise, 15);
+  printf("方向転換 %d° %d\n", rotationAngle, clockwise);
+}
+
+void Navigator::moveC2M()
+{
+  lineTracer.run({ 175, 30, 0.0, { 0.2, 0.005, 0.01 } });
+  printf("交点サークルから中点への移動\n");
+}
+
+void Navigator::getBlockFromC()
+{
+  moveStraight.moveTo(186, 30);
+  printf("交点サークルからブロックサークルのブロックを取得\n");
+}
+
+void Navigator::setBlockFromC()
+{
+  moveStraight.moveTo(185, 15);
+  moveStraight.moveTo(-170, 15);
+  printf("交点サークルからブロックサークルにブロックを設置\n");
+}
+
+void Navigator::moveM2C()
+{
+  lineTracer.runToColor(30, 0.2, 0.005, 0.01, 0.0);
+  moveStraight.moveTo(100, 30);
+  printf("中点から交点サークルへの移動\n");
+}
+
+void Navigator::moveM2M()
+{
+  moveStraight.moveTo(247, 30);
+  printf("中点から中点への移動\n");
+}
+
+void Navigator::getBlockFromM()
+{
+  moveStraight.moveTo(145, 30);
+  printf("中点からブロックサークルのブロックを取得\n");
+}
+
+void Navigator::setBlockFromM()
+{
+  moveStraight.moveTo(145, 30);
+  moveStraight.moveTo(-145, 30);
+  printf("中点からブロックサークルにブロックを設置\n");
+}
+
+void Navigator::moveB2C()
+{
+  moveStraight.moveTo(186, 30);
+  printf("ブロックサークルから交点サークルへの移動\n");
+}
+
+void Navigator::moveB2M()
+{
+  moveStraight.moveTo(145, 30);
+  printf("ブロックサークルから中点への移動\n");
 }

--- a/module/Navigator.cpp
+++ b/module/Navigator.cpp
@@ -68,6 +68,27 @@ void Navigator::execMotion(vector<MotionCommand> const& motionCommandList)
   }
 }
 
+void Navigator::enterStraight()
+{
+  lineTracer.runToColor(30, 0.2, 0.005, 0.01, 0.0);
+  moveStraight.moveTo(110, 30);
+  printf("ビンゴエリアにまっすぐ進入\n");
+}
+
+void Navigator::enterLeft()
+{
+  lineTracer.run({ 70, 30, 0.0, { 0.2, 0.005, 0.01 } });
+  changeDirection(45, true);
+  moveStraight.moveTo(215, 30);
+}
+
+void Navigator::enterRight()
+{
+  lineTracer.run({ 70, 30, 0.0, { 0.2, 0.005, 0.01 } });
+  changeDirection(45, false);
+  moveStraight.moveTo(215, 30);
+}
+
 int Navigator::countRepeatedCommand(vector<MotionCommand> const& motionCommandList, int startIndex)
 {
   MotionCommand startCommand = motionCommandList[startIndex];

--- a/module/Navigator.h
+++ b/module/Navigator.h
@@ -41,7 +41,26 @@ class Navigator {
    */
   Navigator(Controller& controller_, bool isLeftCourse_);
 
+  /**
+   * @brief 動作命令に対応する動作を実行する
+   * @param motionCommandList [動作命令リスト]
+   */
   void execMotion(vector<MotionCommand> const& motionCommandList);
+
+  /**
+   * @brief ビンゴエリアにまっすぐ進入する(Lコースなら(2,6)へ)
+   */
+  void enterStraight();
+
+  /**
+   * @brief ビンゴエリアに左斜めに進入する(Lコースなら(1,6)へ)
+   */
+  void enterLeft();
+
+  /**
+   * @brief ビンゴエリアに右斜めに進入する(Lコースなら(3,6)へ)
+   */
+  void enterRight();
 
  private:
   Controller& controller;

--- a/module/Navigator.h
+++ b/module/Navigator.h
@@ -1,13 +1,33 @@
 /**
  *  @file  Navigator.h
  *  @brief ビンゴエリアを走る
- *  @author sugaken0528
+ *  @author sugaken0528, arimakaoru
  */
 
 #ifndef NAVIGATOR_H
 #define NAVIGATOR_H
 
+#include <vector>
+#include "MoveStraight.h"
 #include "LineTracer.h"
+#include "Rotation.h"
+
+using std::abs;
+using std::vector;
+
+enum class MotionCommand {
+  RT,  // 時計回りに45°方向転換(Rotation True)
+  RF,  // 反時計回りに45°方向転換(Rotation False)
+  CM,  // 交点サークル→中点の移動(Cross circle to Middle point)
+  GC,  // 交点サークルからブロックサークルのブロックを取得する(Get block from Cross circle)
+  SC,  // 交点サークルからブロックサークルにブロックを設置する(Set block from Cross circle)
+  MC,  // 中点→交点サークルの移動(Middle point to Cross circle)
+  MM,  // 中点→中点の移動(Midlle point to Middle point)
+  GM,  // 中点からブロックサークルのブロックを取得する(Get block from Middle point)
+  SM,  // 中点からブロックサークルにブロックを設置する(Set block from Middle point)
+  BC,  // ブロックサークル→交点サークルの移動(Block circle to Cross circle)
+  BM   // ブロックサークル→中点の移動(Block circle to Middle point)
+};
 
 class Navigator {
  public:
@@ -16,20 +36,79 @@ class Navigator {
    *
    * @brief Navigatorクラスのコンストラクタ
    * @param &controller_ [Controllerインスタンスの参照]
-   * @param isLeftCourse_ [エッジがどっちかtrueがLeftコース]
+   * @param isLeftCourse_ [コースがどっちかtrueがLeftコース]
    * @param targetBrightness_ [黒と白の閾値]
    */
-  Navigator(Controller& controller_, bool isLeftCourse_, int targetBrightness_);
+  Navigator(Controller& controller_, bool isLeftCourse_);
 
-  /**
-   * 実際にビンゴエリアを走る．
-   */
-  void traceBingoArea(bool isRightEdge);
+  void execMotion(vector<MotionCommand> const& motionCommandList);
 
  private:
   Controller& controller;
   bool isLeftCourse;
-  int targetBrightness;
+  bool isLeftEdge;
+  MoveStraight moveStraight;
+  LineTracer lineTracer;
+  Rotation rotation;
+
+  /**
+   * @brief 同じ動作命令が連続して繰り返されている回数を数える
+   * @param motionCommandList [動作命令リスト]
+   * @param startIndex [カウントを始めるインデックス]
+   */
+  int countRepeatedCommand(vector<MotionCommand> const& motionCommandList, int startIndex);
+
+  /**
+   * @brief 方向転換
+   * @param rotationAngle [方向転換に必要な角度]
+   * @param clockwise     [方向転換の向き、正=時計回り、負=反時計回り]
+   */
+  void changeDirection(unsigned int rotationAngle, bool clockwise);
+
+  /**
+   * @brief 交点サークルから中点への移動
+   */
+  void moveC2M();
+
+  /**
+   * @brief 交点サークルからブロックサークルのブロックを取得する
+   */
+  void getBlockFromC();
+
+  /**
+   * @brief 交点サークルからブロックサークルにブロックを設置する
+   */
+  void setBlockFromC();
+
+  /**
+   * @brief 中点から交点サークルへの移動
+   */
+  void moveM2C();
+
+  /**
+   * @brief 中点から中点への移動
+   */
+  void moveM2M();
+
+  /**
+   * @brief 中点からブロックサークルのブロックを取得する
+   */
+  void getBlockFromM();
+
+  /**
+   * @brief 中点からブロックサークルにブロックを設置する
+   */
+  void setBlockFromM();
+
+  /**
+   * @brief ブロックサークルから交点サークルへの移動
+   */
+  void moveB2C();
+
+  /**
+   * @brief ブロックサークルから中点への移動
+   */
+  void moveB2M();
 };
 
 #endif

--- a/module/api/Controller.cpp
+++ b/module/api/Controller.cpp
@@ -210,6 +210,16 @@ int Controller::suppressPwmValue(const int value)
   return value;
 }
 
+int Controller::getTargetBrightness()
+{
+  return targetBrightness;
+}
+
+void Controller::setTargetBrightness(int brightness_)
+{
+  targetBrightness = brightness_;
+}
+
 void Controller::setLeftMotorPwm(const int pwm)
 {
   leftWheel.setPWM(suppressPwmValue(pwm));

--- a/module/api/Controller.h
+++ b/module/api/Controller.h
@@ -63,6 +63,8 @@ class Controller {
   int getLeftMotorCount();
   int getRightMotorCount();
   int getArmMotorCount();
+  int getTargetBrightness();
+  void setTargetBrightness(int brightness_);
   void setLeftMotorPwm(const int pwm);
   void setRightMotorPwm(const int pwm);
   void setArmMotorPwm(const int pwm);
@@ -103,6 +105,7 @@ class Controller {
   void notifyCompleted(void);
 
  private:
+  int targetBrightness = 127;
   HsvStatus hsv;
   Motor liftMotor;
   Motor rightWheel;

--- a/test/BlockBingoDataTest.cpp
+++ b/test/BlockBingoDataTest.cpp
@@ -5,6 +5,9 @@
  */
 #include "BlockBingoData.h"
 #include <gtest/gtest.h>
+#include <vector>
+
+using std::vector;
 
 namespace etrobocon2020_test {
 
@@ -391,5 +394,37 @@ namespace etrobocon2020_test {
     blockBingoData.setDirection(expected);
     actual = blockBingoData.getDirection();
     ASSERT_EQ(expected, actual);
+  }
+
+  TEST(BlockBingoData, calcNextDirectionTest)
+  {
+    Controller controller;
+    bool isLeftCourse = true;
+    BlockBingoData blockBingoData(controller, isLeftCourse);
+
+    Coordinate current = { 2, 2 };
+    vector<Coordinate> next
+        = { { 2, 1 }, { 3, 1 }, { 3, 2 }, { 3, 3 }, { 2, 3 }, { 1, 3 }, { 1, 2 }, { 1, 1 } };
+    vector<Direction> expected = { Direction::North, Direction::NEast, Direction::East,
+                                   Direction::SEast, Direction::South, Direction::SWest,
+                                   Direction::West,  Direction::NWest, Direction::North };
+    for(int i = 0; i < next.size(); i++) {
+      ASSERT_EQ(expected[i], blockBingoData.calcNextDirection(current, next[i]));
+    }
+  }
+
+  TEST(BlockBingoData, hasBlockTest)
+  {
+    Controller controller;
+    bool isLeftCourse = true;
+    BlockBingoData blockBingoData(controller, isLeftCourse);
+
+    Coordinate coordinateTrue(2, 6);
+    Block block(Color::blue, -1);
+    blockBingoData.setBlock(coordinateTrue, block);
+    ASSERT_TRUE(blockBingoData.hasBlock(coordinateTrue));
+
+    Coordinate coordinateFalse(0, 0);
+    ASSERT_FALSE(blockBingoData.hasBlock(coordinateFalse));
   }
 }  // namespace etrobocon2020_test

--- a/test/BlockBingoDataTest.cpp
+++ b/test/BlockBingoDataTest.cpp
@@ -405,9 +405,9 @@ namespace etrobocon2020_test {
     Coordinate current = { 2, 2 };
     vector<Coordinate> next
         = { { 2, 1 }, { 3, 1 }, { 3, 2 }, { 3, 3 }, { 2, 3 }, { 1, 3 }, { 1, 2 }, { 1, 1 } };
-    vector<Direction> expected = { Direction::North, Direction::NEast, Direction::East,
-                                   Direction::SEast, Direction::South, Direction::SWest,
-                                   Direction::West,  Direction::NWest, Direction::North };
+    vector<Direction> expected
+        = { Direction::North, Direction::NEast, Direction::East, Direction::SEast,
+            Direction::South, Direction::SWest, Direction::West, Direction::NWest };
     for(int i = 0; i < next.size(); i++) {
       ASSERT_EQ(expected[i], blockBingoData.calcNextDirection(current, next[i]));
     }

--- a/test/MotionSequencerTest.cpp
+++ b/test/MotionSequencerTest.cpp
@@ -1,0 +1,236 @@
+/**
+ *  @file   MotionSequencerTest.cpp
+ *  @brief  MotionSequencerクラスのテストファイル
+ *  @author Arima Kaoru
+ */
+#include "MotionSequencer.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2020_test {
+  TEST(MotionSequencer, route2MotionCommand)
+  {
+    Controller controller;
+    bool isLeftCourse = true;
+    BlockBingoData blockBingoData(controller, isLeftCourse);
+    blockBingoData.initBlockBingoData();
+    MotionSequencer motionSequencer(blockBingoData);
+
+    // (2,6)の青ブロックを(4,4)に設置
+    vector<Coordinate> route = { { 2, 6 }, { 3, 6 }, { 4, 6 }, { 5, 5 } };
+    vector<MotionCommand> expected = { MotionCommand::RT, MotionCommand::RT, MotionCommand::CM,
+                                       MotionCommand::MC, MotionCommand::RF, MotionCommand::SC };
+    vector<MotionCommand> actual;
+    Direction nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::NEast, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::blue));
+
+    // (4,4)の黄色ブロックを取得
+    route = { { 4, 6 }, { 4, 5 }, { 4, 4 } };
+    expected = { MotionCommand::RF, MotionCommand::CM, MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::North, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (4,4)の黄色ブロックを(1,1)に設置
+    route = { { 4, 4 }, { 4, 3 }, { 4, 2 }, { 4, 1 }, { 3, 0 }, { 2, 0 }, { 1, 1 } };
+    expected = { MotionCommand::CM, MotionCommand::MC, MotionCommand::CM,
+                 MotionCommand::RF, MotionCommand::MM, MotionCommand::RF,
+                 MotionCommand::MC, MotionCommand::RF, MotionCommand::SC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::SWest, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::yellow));
+
+    // (0,0)の青ブロック取得
+    route = { { 2, 0 }, { 1, 0 }, { 0, 0 } };
+    expected = { MotionCommand::RT, MotionCommand::CM, MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::West, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (0,0)の青ブロックを(1,3)に設置
+    route = { { 0, 0 }, { 0, 1 }, { 0, 2 }, { 1, 3 } };
+    expected = { MotionCommand::RF, MotionCommand::RF, MotionCommand::CM,
+                 MotionCommand::MC, MotionCommand::RF, MotionCommand::SC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::SEast, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::blue));
+
+    // (2,2)の緑ブロックを取得
+    route = { { 0, 2 }, { 1, 2 }, { 2, 2 } };
+    expected = { MotionCommand::RF, MotionCommand::CM, MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::East, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (2,2)の緑ブロックを(3,1)に運ぶ
+    route = { { 2, 2 }, { 3, 1 } };
+    expected = { MotionCommand::RF, MotionCommand::SC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::NEast, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::green));
+
+    // (6,2)の赤ブロックを取得
+    route = { { 2, 2 }, { 3, 2 }, { 4, 2 }, { 5, 2 }, { 6, 2 } };
+    expected = { MotionCommand::RT, MotionCommand::CM, MotionCommand::MC, MotionCommand::CM,
+                 MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::East, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (6,2)の赤ブロックを(5,1)に設置
+    route = { { 6, 2 }, { 5, 1 } };
+    expected = { MotionCommand::RF, MotionCommand::RF, MotionCommand::RF, MotionCommand::SC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::NWest, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::red));
+
+    // (4,0)の数字カード黒ブロックを取得
+    route = { { 6, 2 }, { 6, 1 }, { 6, 0 }, { 5, 0 }, { 4, 0 } };
+    expected = { MotionCommand::RT, MotionCommand::CM, MotionCommand::MC, MotionCommand::RF,
+                 MotionCommand::RF, MotionCommand::CM, MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::West, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (4,0)の数字カード黒ブロックを(5,1)に設置
+    route = { { 4, 0 }, { 5, 1 } };
+    expected = { MotionCommand::RF, MotionCommand::RF, MotionCommand::RF, MotionCommand::SC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::SEast, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::black));
+
+    // (3,5)の緑ブロックを取得
+    route = { { 4, 0 }, { 4, 1 }, { 4, 2 }, { 4, 3 }, { 4, 4 }, { 3, 5 } };
+    expected = { MotionCommand::RT, MotionCommand::CM, MotionCommand::MC, MotionCommand::CM,
+                 MotionCommand::MC, MotionCommand::RT, MotionCommand::GC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::SWest, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (3,5)の緑ブロックを(1,5)に設置
+    route = { { 3, 5 }, { 2, 5 }, { 1, 5 } };
+    expected = { MotionCommand::RT, MotionCommand::BM, MotionCommand::SM };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::West, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::green));
+
+    // (0,4)の赤ブロックを取得
+    route = { { 2, 5 }, { 2, 4 }, { 1, 4 }, { 0, 4 } };
+    expected = { MotionCommand::RT, MotionCommand::RT, MotionCommand::MC, MotionCommand::RF,
+                 MotionCommand::RF, MotionCommand::CM, MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::West, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+
+    // (0,4)の赤ブロックを(3,5)に設置
+    route = { { 0, 4 }, { 1, 4 }, { 2, 4 }, { 3, 5 } };
+    expected = { MotionCommand::RF, MotionCommand::RF, MotionCommand::RF, MotionCommand::RF,
+                 MotionCommand::CM, MotionCommand::MC, MotionCommand::RT, MotionCommand::SC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::SEast, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(Direction::SEast);
+    blockBingoData.setBlock(route.front(), Block(Color::none));
+    blockBingoData.setBlock(route.back(), Block(Color::red));
+
+    // ガレージ停止開始座標(0,6)に移動
+    route = { { 2, 4 }, { 2, 5 }, { 2, 6 }, { 1, 6 }, { 0, 6 } };
+    expected = { MotionCommand::RT, MotionCommand::CM, MotionCommand::MC, MotionCommand::RT,
+                 MotionCommand::RT, MotionCommand::CM, MotionCommand::MC };
+    actual.clear();
+    nextDirection = motionSequencer.route2MotionCommand(route, actual);
+    ASSERT_EQ(Direction::West, nextDirection);
+    ASSERT_EQ(expected.size(), actual.size());
+    for(int i = 0; i < expected.size(); i++) {
+      ASSERT_EQ(expected[i], actual[i]);
+    }
+    blockBingoData.setDirection(nextDirection);
+  }
+}  // namespace etrobocon2020_test

--- a/test/dummy/Controller.cpp
+++ b/test/dummy/Controller.cpp
@@ -42,3 +42,13 @@ int Controller::getCourseInfo(ETROBOC_COURSE_INFO_ID id)
 }
 
 void Controller::notifyCompleted(void) {}
+
+int Controller::getTargetBrightness()
+{
+  return targetBrightness;
+}
+
+void Controller::setTargetBrightness(int brightness_)
+{
+  targetBrightness = brightness_;
+}

--- a/test/dummy/Controller.h
+++ b/test/dummy/Controller.h
@@ -376,5 +376,11 @@ class Controller {
    * @note    dummy Contoellerでは、何もしない
    */
   void notifyCompleted(void);
+
+  int getTargetBrightness();
+  void setTargetBrightness(int brightness_);
+
+ private:
+  int targetBrightness;
 };
 #endif


### PR DESCRIPTION
## チェックリスト

- [x] clang-format した
- [x] コーディング規約に準じている
- [x] テストに通った

## 変更点

- MotionSequencerクラスは、経路→動作命令に変換する
- Navigatorクラスは、動作命令に応じて、走行体を動かす
- Navigatorクラスの各動作は調整が必要

## テスト結果
- MotionSequencerクラスのroute2MotionCommand関数のテストコードで、競技規約p26「初期設置の例」
でのフルビンゴ成立+数字カード黒ブロック設置+ガレージ停止開始座標へ移動までの成功を確認した。

- シミュレータで実行して、(2,6)の青ブロックを(5,5)のブロックサークルに設置できることを確認した。(それ以降は、走行体動作の失敗で確認できず。走行体動作は要調整)